### PR TITLE
feat!: use ubi9 upstream

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -4,19 +4,10 @@ on:
   push:
     branches:
       - main
+      - release/*
 
 jobs:
-  semantic-release:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Run go-semantic-release
-        id: semrel
-        uses: go-semantic-release/action@v1
-        with:
-          github-token: ${{ secrets.RABE_ITREAKTION_GITHUB_TOKEN }}
-          allow-initial-development-versions: true
+  call-workflow:
+    uses: radiorabe/actions/.github/workflows/semantic-release.yaml@main
+    secrets:
+      RABE_ITREAKTION_GITHUB_TOKEN: ${{ secrets.RABE_ITREAKTION_GITHUB_TOKEN }}

--- a/.semrelrc
+++ b/.semrelrc
@@ -1,0 +1,3 @@
+{
+  "maintainedVersion": "2-alpha"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/radiorabe/ubi8-minimal:0.5.1
+FROM ghcr.io/radiorabe/ubi9-minimal:0.1.1
 
 ENV \
     # Path to be used in other layers to place s2i scripts into
@@ -9,7 +9,7 @@ ENV \
     PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     PLATFORM="el8"
 
-COPY --from=registry.access.redhat.com/ubi8/s2i-core:1-282 \
+COPY --from=registry.access.redhat.com/ubi9/s2i-core:1-373 \
      /usr/bin/base-usage \
      /usr/bin/container-entrypoint \
      /usr/bin/cgroup-limits \
@@ -17,7 +17,7 @@ COPY --from=registry.access.redhat.com/ubi8/s2i-core:1-282 \
      /usr/bin/prepare-yum-repositories \
      /usr/bin/rpm-file-permissions \
      /usr/bin/
-COPY --from=registry.access.redhat.com/ubi8/s2i-core:1-282 \
+COPY --from=registry.access.redhat.com/ubi9/s2i-core:1-373 \
      /opt/app-root/etc/scl_enable \
      /opt/app-root/etc/
 


### PR DESCRIPTION
Port S2I infrastructure to the updated ubi9 based [container-image-ubi9-minimal](https://github.com/radiorabe/container-image-ubi9-minimal) base image.

* [ ] e2e tests with a bunch of use cases
* [ ] remove semrelrc